### PR TITLE
修复兑换码请求头

### DIFF
--- a/TGDSign/tgdsign_code/__init__.py
+++ b/TGDSign/tgdsign_code/__init__.py
@@ -15,6 +15,14 @@ sv_tgd_code = SV("异环兑换码")
 invalid_code_list = ()
 
 url = "https://newsimg.5054399.com/comm/mlcxqcommon/static/wap/js/data_173.js?{}&callback=?&_={}"
+request_headers = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36"
+    ),
+    "Referer": "https://www.4399.com/",
+    "Accept": "*/*",
+}
 
 
 @sv_tgd_code.on_fullmatch(("code", "兑换码", "兌換碼"))
@@ -46,7 +54,8 @@ async def get_code_list():
         now_time = int(time.time() * 1000)
         new_url = url.format(time_string, now_time)
         async with httpx.AsyncClient(timeout=None) as client:
-            res = await client.get(new_url, timeout=10)
+            res = await client.get(new_url, headers=request_headers, timeout=10)
+            res.raise_for_status()
             json_data = res.text.split("=", 1)[1].strip().rstrip(";")
             logger.debug(f"[获取兑换码] url:{new_url}, codeList:{json_data}")
             return json.loads(json_data)


### PR DESCRIPTION
## Summary
- Add browser-like headers when fetching the 4399 code-list JavaScript file.
- Check HTTP error status before parsing the response as JSONP.

## Root Cause
The 4399 CDN now returns a 403 HTML page for default programmatic requests. The code then parsed that HTML as a JSONP payload, producing `JSONDecodeError: Extra data`.

## Validation
- `python -m py_compile TGDSign/tgdsign_code/__init__.py`
- Fetched and parsed `data_173.js` with the same headers, receiving HTTP 200 and a valid code list.
